### PR TITLE
⭐feat: JPQL을 활용한 가장 최신 Response 데이터 가져오기 및 예외 처리 구현

### DIFF
--- a/src/main/java/com/movie_ai_recommend/movie_ai_recommend/controller/chat/ChatController.java
+++ b/src/main/java/com/movie_ai_recommend/movie_ai_recommend/controller/chat/ChatController.java
@@ -1,0 +1,40 @@
+package com.movie_ai_recommend.movie_ai_recommend.controller.chat;
+
+import com.movie_ai_recommend.movie_ai_recommend.dto.gemini.GeminiRequestDto;
+import com.movie_ai_recommend.movie_ai_recommend.repository.ChatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Chat API
+ *
+ * 1. Gemini AI Response Data 조회
+ */
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatController {
+
+    private final ChatRepository chatRepository;
+
+    @GetMapping("/latest-response")
+    public ResponseEntity<?> getLatestResponse(@RequestBody GeminiRequestDto geminiRequestDto) {
+        try {
+            String response = chatRepository.findLatestResponseByUserId(geminiRequestDto.getUserId());
+
+            if (response != null) {
+                return ResponseEntity.ok(response);
+            } else {
+                return ResponseEntity.notFound().build();
+            }
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body("최신 응답 조회 중 오류 발생: " + e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/movie_ai_recommend/movie_ai_recommend/repository/ChatRepository.java
+++ b/src/main/java/com/movie_ai_recommend/movie_ai_recommend/repository/ChatRepository.java
@@ -2,8 +2,19 @@ package com.movie_ai_recommend.movie_ai_recommend.repository;
 
 import com.movie_ai_recommend.movie_ai_recommend.entity.Chat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRepository extends JpaRepository<Chat, Long> {
+
+    /**
+     * JPQL을 사용한 가장 최신의 Response 값 하나 조회하기
+     *
+     * @param userId
+     * @return
+     */
+    @Query("SELECT c.response FROM Chat c WHERE c.user.id = :userId ORDER BY c.createdAt DESC limit 1")
+    String findLatestResponseByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## ⭐ 주요 구현 내용
---
1. **JPQL**을 활용한 `createdAt` 기준 정렬을 통해 **LIMIT 1**의 값을 가져오기
2. **Chat Controller**에서 `response`에 대한 예외 처리


## 👍 주요 구현 기능
---
![image](https://github.com/user-attachments/assets/9c74998a-5504-4d98-a173-07c70fc83f1b)


## 💡 개선 사항
---
### ChatController
```java
@GetMapping("/latest-response")
    public ResponseEntity<?> getLatestResponse(@RequestBody GeminiRequestDto geminiRequestDto)
```

위의 코드와 같이 현재 **Chat Controller**에서 `GeminiRequestDto`를 재사용하고 있음. 해당 `DTO` 안에는 `userId`값 하나여서 재사용을 하였는데, 코드 가독성이나 유지/보수 측면에서... 똑같이 `userId`값 하나만 사용하더라도 새로운 `ChatDto`를 만드는 게 좋을지 의문임. **_추후에 더 확인해 볼 예정_**


## 📕 Todo List
---
1. 영화 추천 받기 페이지 구현
